### PR TITLE
Drop short-hash on main branch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -42113,10 +42113,17 @@ async function calculateVersion(context) {
   // Get the latest release
   const parsed = await getPreviousReleaseVersion(context);
   const nextVersion = parsed.inc("minor");
-  const shortHash = context.sha.slice(0, 7);
   const timestamp = await getTimestamp(context);
-  const version = `${nextVersion.version}-alpha.${timestamp}+${shortHash}`;
-  return version;
+  if (
+    context.eventName === "push" &&
+    (context.ref === "refs/heads/master" || context.ref === "refs/heads/main")
+  ) {
+    // If we're building the main branch, don't include the `+{shortHash}` part as Python considers this a "local" version
+    // and will not allow it to be uploaded to PyPI.
+    return `${nextVersion.version}-alpha.${timestamp}`;
+  }
+  const shortHash = context.sha.slice(0, 7);
+  return `${nextVersion.version}-alpha.${timestamp}+${shortHash}`;
 }
 
 async function getPreviousReleaseVersion(context) {

--- a/version.js
+++ b/version.js
@@ -22,10 +22,17 @@ export async function calculateVersion(context) {
   // Get the latest release
   const parsed = await getPreviousReleaseVersion(context);
   const nextVersion = parsed.inc("minor");
-  const shortHash = context.sha.slice(0, 7);
   const timestamp = await getTimestamp(context);
-  const version = `${nextVersion.version}-alpha.${timestamp}+${shortHash}`;
-  return version;
+  if (
+    context.eventName === "push" &&
+    (context.ref === "refs/heads/master" || context.ref === "refs/heads/main")
+  ) {
+    // If we're building the main branch, don't include the `+{shortHash}` part as Python considers this a "local" version
+    // and will not allow it to be uploaded to PyPI.
+    return `${nextVersion.version}-alpha.${timestamp}`;
+  }
+  const shortHash = context.sha.slice(0, 7);
+  return `${nextVersion.version}-alpha.${timestamp}+${shortHash}`;
 }
 
 async function getPreviousReleaseVersion(context) {

--- a/version.test.js
+++ b/version.test.js
@@ -23,7 +23,7 @@ describe("Tag pushed", () => {
   });
 });
 
-describe("Branch pushed", () => {
+describe("main/master branch pushed", () => {
   test("with previous release", async () => {
     // Mock the latest release response
     fetch.mockResponseOnce(async () => ({
@@ -48,7 +48,7 @@ describe("Branch pushed", () => {
           repo: "repo",
         },
       })
-    ).toBe("1.1.0-alpha.1577836800+699a10d");
+    ).toBe("1.1.0-alpha.1577836800");
   });
 
   test("without previous release", async () => {
@@ -75,10 +75,10 @@ describe("Branch pushed", () => {
           repo: "repo",
         },
       })
-    ).toBe("0.1.0-alpha.1577836800+699a10d");
+    ).toBe("0.1.0-alpha.1577836800");
   });
 
-  test("failure to fetch commit", async () => {
+  test("failure to fetch commit falls back to runId", async () => {
     // Mock the latest release response
     fetch.mockResponseOnce(async () => ({
       body: JSON.stringify({ tag_name: "v1.0.0" }),
@@ -101,7 +101,7 @@ describe("Branch pushed", () => {
           repo: "repo",
         },
       })
-    ).toBe("1.1.0-alpha.1234+699a10d");
+    ).toBe("1.1.0-alpha.1234");
   });
 });
 


### PR DESCRIPTION
If we're building the main branch, don't include the `+{shortHash}` part as Python considers this a "local" version and will not allow it to be uploaded to PyPI.