### PR TITLE
Fix scheduled events failing with unsupported event error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -42172,6 +42172,14 @@ async function calculateVersion(context) {
     return localAlphaVersion(nextVersion, timestamp, shortHash);
   }
 
+  if (eventName === "schedule") {
+    const previousRelease = await getLatestReleaseVersion(context.repo);
+    const nextVersion = previousRelease.inc("minor");
+    const timestamp = await getCommitTimestamp(context.repo, sha);
+    const shortHash = context.sha.slice(0, 7);
+    return localAlphaVersion(nextVersion, timestamp, shortHash);
+  }
+
   throw new Error(`Unsupported event: ${eventName}`);
 }
 

--- a/version.js
+++ b/version.js
@@ -80,6 +80,14 @@ export async function calculateVersion(context) {
     return localAlphaVersion(nextVersion, timestamp, shortHash);
   }
 
+  if (eventName === "schedule") {
+    const previousRelease = await getLatestReleaseVersion(context.repo);
+    const nextVersion = previousRelease.inc("minor");
+    const timestamp = await getCommitTimestamp(context.repo, sha);
+    const shortHash = context.sha.slice(0, 7);
+    return localAlphaVersion(nextVersion, timestamp, shortHash);
+  }
+
   throw new Error(`Unsupported event: ${eventName}`);
 }
 

--- a/version.test.js
+++ b/version.test.js
@@ -250,6 +250,32 @@ describe("pull_request", () => {
   });
 });
 
+describe("schedule", () => {
+  test("to default branch", async () => {
+    mockGitHubEndpoints({
+      "repos/owner/repo/releases/latest": { tag_name: "v1.2.1" },
+      "repos/owner/repo/commits/699a10d86efd595503aa8c3ecfff753a7ed3cbd4": {
+        commit: {
+          message: "Commit message",
+          committer: { date: "2020-01-01T00:00:00Z" },
+        },
+      },
+    });
+
+    expect(
+      await calculateVersion({
+        eventName: "schedule",
+        sha: "699a10d86efd595503aa8c3ecfff753a7ed3cbd4",
+        ref: "refs/heads/master",
+        repo: {
+          owner: "owner",
+          repo: "repo",
+        },
+      })
+    ).toBe("1.3.0-alpha.1577836800+699a10d");
+  });
+});
+
 function mockGitHubEndpoints(requests = {}) {
   fetch.mockResponse(async (req) => {
     const url = req.url;


### PR DESCRIPTION
Previously the versioning action defaulted to a local alpha version for any unknown event types. Now that event types are explicitly checked an error is thrown if an unknown type is encountered.
Handling for the 'schedule' event was missing, which caused failures for providers with cron jobs.
This change adds the necessary handling for 'schedule' events and constructs a local development version for those like before.
