### PR TITLE
Add support for workflow_dispatch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -42120,12 +42120,19 @@ async function calculateVersion(context) {
     return calculateTagVersion(ref);
   }
 
-  if (eventName === "push" && ref.startsWith("refs/heads/")) {
+  if (
+    (eventName === "push" || eventName == "workflow_dispatch") &&
+    ref.startsWith("refs/heads/")
+  ) {
     // push events only
-    const headCommitTimestamp = context.payload?.head_commit?.timestamp;
-    const headCommitMessage = context.payload?.head_commit?.message;
+    let headCommitTimestamp = context.payload?.head_commit?.timestamp;
+    const headCommitMessage = context.payload?.head_commit?.message ?? "";
     localDebug(`head_commit.timestamp: ${headCommitTimestamp}`);
     localDebug(`head_commit.message: ${headCommitMessage}`);
+
+    if (headCommitTimestamp === undefined) {
+      headCommitTimestamp = await getCommitTimestamp(context.repo, sha);
+    }
 
     const branchName = ref.replace("refs/heads/", "");
     const asVersion = tryParseVersionBranch(branchName);
@@ -42275,6 +42282,9 @@ function getIncrementTypeFromLabels(labels) {
  * @returns {number | undefined}
  */
 function tryParsePrNumber(commitMessage) {
+  if (!commitMessage) {
+    return undefined;
+  }
   const prMatch = commitMessage.match(/\(#(\d+)\)/);
   if (prMatch) {
     const num = parseInt(prMatch[1], 10);
@@ -42345,6 +42355,7 @@ async function getCommitTimestamp(repo, sha) {
   if (commitDate === undefined) {
     throw new Error("Could not find commit date");
   }
+  localDebug(`Commit date: ${commitDate}`);
   return commitDate;
 }
 

--- a/version.test.js
+++ b/version.test.js
@@ -78,6 +78,35 @@ describe("main/master branch pushed", () => {
   });
 });
 
+describe("workflow_dispatch", () => {
+  test("with previous release", async () => {
+    mockGitHubEndpoints({
+      "repos/owner/repo/releases/latest": { tag_name: "v1.0.0" },
+      "repos/owner/repo/commits/699a10d86efd595503aa8c3ecfff753a7ed3cbd4": {
+        commit: {
+          message: "Commit message",
+          committer: { date: "2020-01-01T00:00:00Z" },
+        },
+      },
+    });
+
+    expect(
+      await calculateVersion({
+        eventName: "workflow_dispatch",
+        sha: "699a10d86efd595503aa8c3ecfff753a7ed3cbd4",
+        ref: "refs/heads/master",
+        repo: {
+          owner: "owner",
+          repo: "repo",
+        },
+        payload: {
+          repository: { default_branch: "master" },
+        },
+      })
+    ).toBe("1.1.0-alpha.1577836800");
+  });
+});
+
 describe("Version branch pushed", () => {
   test("with previous release", async () => {
     mockGitHubEndpoints({});


### PR DESCRIPTION
- Treat workflow_dispatch the same as a branch push - as you have to specify a branch or tag when triggering.
- Workflow dispatch contains head and sha, but likely doesn't have head_commit information, so ensure we can fall back to.

Test run using a workflow_dispatch: https://github.com/pulumi/provider-version-action/actions/runs/9303109491