### PR TITLE
Handle merging version branches into the default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ This action supports 3 build scenarios:
 When we're wanting to build for a different major version from the last release, we can do this using two methods:
 
 1. Use a version branch containing just the major version number e.g. (`v1` or `v7`). Pushing to this branch, or opening a pull request with this branch as the "base" will use this major version.
-2. Add the label `needs-release/major` to a pull request. This will cause the version number to be incremented by a major increment instead of a minor increment. The major increment will be used when building the PR and when building the commit after being merged.
+2. Add the label `needs-release/major` to a pull request. This will cause the version number to be incremented by a major increment instead of a minor increment.
 
-Note: if the `needs-release/major` label is used on a version branch, the label will be ignored and the version branch used.
+After a major version upgrade PR is merged, the next build of the default branch will also use the new major version.
+
+Note: If both a version branch and a `needs-release/major` label used, the version branch will take priority.
 
 ## Alpha Version Format
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ This action supports 3 build scenarios:
 
 ### Major Versions
 
-When we're wanting to build for a different major version from the last release, we can do this using two methods:
+When we're wanting to build for a different major version from the last release, we can do this using three methods:
 
 1. Use a version branch containing just the major version number e.g. (`v1` or `v7`). Pushing to this branch, or opening a pull request with this branch as the "base" will use this major version.
-2. Add the label `needs-release/major` to a pull request. This will cause the version number to be incremented by a major increment instead of a minor increment.
+2. Name the branch with prefix `upgrade-` and suffix `-major` (e.g. `upgrade-aws-to-v2.0.0-major`). This will cause the version number to be incremented by a major increment instead of a minor increment.
+3. Add the label `needs-release/major` to a pull request. This will cause the version number to be incremented by a major increment instead of a minor increment.
 
 After a major version upgrade PR is merged, the next build of the default branch will also use the new major version.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -42240,10 +42240,15 @@ function tryParseVersionBranch(branchName) {
 }
 
 /**
- * Checks the PR to see if the major version should be incremented based on labels.
+ * Calculates the next version number that will be released
+ * for a default branch push event. This is determined by
+ * the latest release version and the commit message.
+ * If the commit message contains a PR number, the PR's branch
+ * name will be checked for a version number. Otherwise, the
+ * increment type will be determined by PR labels.
  * @param {{ owner: string, repo: string }} repo
  * @param {string} commitMessage
- * @returns {Promise<SemVer>}
+ * @returns {Promise<SemVer>} The next version number to be released.
  */
 async function getDefaultBranchNextVersion(repo, commitMessage) {
   const previousRelease = await getLatestReleaseVersion(repo);
@@ -42256,13 +42261,15 @@ async function getDefaultBranchNextVersion(repo, commitMessage) {
     ...repo,
     pull_number: prNumber,
   });
+  // Check if the PR branch name is a version branch
   const prRef = pr.data?.head?.ref;
   if (prRef !== undefined) {
-    const asVersion = tryParseVersionBranch(prRef);
-    if (asVersion !== undefined) {
-      return new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer(`${asVersion}.0.0`);
+    const prBranchVersion = tryParseVersionBranch(prRef);
+    if (prBranchVersion !== undefined) {
+      return new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer(`${prBranchVersion}.0.0`);
     }
   }
+  // Otherwise, determine the increment type from the PR labels
   const increment = getIncrementTypeFromLabels(pr.data?.labels);
   return previousRelease.inc(increment);
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -42142,9 +42142,10 @@ async function calculateVersion(context) {
     }
     if (branchName === defaultBranch) {
       localDebug(`Default branch pushed: ${defaultBranch}`);
-      const previousRelease = await getLatestReleaseVersion(context.repo);
-      const increment = await getIncrementType(context.repo, headCommitMessage);
-      const nextVersion = previousRelease.inc(increment);
+      const nextVersion = await getDefaultBranchNextVersion(
+        context.repo,
+        headCommitMessage
+      );
       return alphaVersion(nextVersion, headCommitTimestamp);
     }
     localDebug(`Branch pushed: ${branchName}`);
@@ -42242,15 +42243,28 @@ function tryParseVersionBranch(branchName) {
  * Checks the PR to see if the major version should be incremented based on labels.
  * @param {{ owner: string, repo: string }} repo
  * @param {string} commitMessage
- * @returns {Promise<'minor' | 'major'>}
+ * @returns {Promise<SemVer>}
  */
-async function getIncrementType(repo, commitMessage) {
+async function getDefaultBranchNextVersion(repo, commitMessage) {
+  const previousRelease = await getLatestReleaseVersion(repo);
   const prNumber = tryParsePrNumber(commitMessage);
   if (prNumber === undefined) {
-    return "minor";
+    return previousRelease.inc("minor");
   }
-  const labels = await findAssociatedPrLabels(repo, prNumber);
-  return getIncrementTypeFromLabels(labels);
+  const octokit = new octokit__WEBPACK_IMPORTED_MODULE_2__.Octokit({ auth: process.env.GITHUB_TOKEN });
+  const pr = await octokit.rest.pulls.get({
+    ...repo,
+    pull_number: prNumber,
+  });
+  const prRef = pr.data?.head?.ref;
+  if (prRef !== undefined) {
+    const asVersion = tryParseVersionBranch(prRef);
+    if (asVersion !== undefined) {
+      return new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer(`${asVersion}.0.0`);
+    }
+  }
+  const increment = getIncrementTypeFromLabels(pr.data?.labels);
+  return previousRelease.inc(increment);
 }
 
 /**
@@ -42291,20 +42305,6 @@ function tryParsePrNumber(commitMessage) {
     }
   }
   return undefined;
-}
-
-/**
- * @param {{ owner:string, repo: string }} repo
- * @param {number} prNumber
- * @returns {Promise<{ name: string }[] | undefined>}
- */
-async function findAssociatedPrLabels(repo, prNumber) {
-  const octokit = new octokit__WEBPACK_IMPORTED_MODULE_2__.Octokit({ auth: process.env.GITHUB_TOKEN });
-  const pr = await octokit.rest.pulls.get({
-    ...repo,
-    pull_number: prNumber,
-  });
-  return pr.data?.labels;
 }
 
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -42084,13 +42084,10 @@ try {
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2186);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony import */ var _actions_github__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(5438);
-/* harmony import */ var _actions_github__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(_actions_github__WEBPACK_IMPORTED_MODULE_1__);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(1383);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__nccwpck_require__.n(semver__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var octokit__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(7467);
-/* harmony import */ var octokit__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__nccwpck_require__.n(octokit__WEBPACK_IMPORTED_MODULE_3__);
-
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(1383);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(semver__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var octokit__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(7467);
+/* harmony import */ var octokit__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__nccwpck_require__.n(octokit__WEBPACK_IMPORTED_MODULE_2__);
 
 
 
@@ -42137,7 +42134,7 @@ async function calculateVersion(context) {
     const branchName = ref.replace("refs/heads/", "");
     const asVersion = tryParseVersionBranch(branchName);
     if (asVersion !== undefined) {
-      const baseVersion = new semver__WEBPACK_IMPORTED_MODULE_2__.SemVer(`${asVersion}.0.0`);
+      const baseVersion = new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer(`${asVersion}.0.0`);
       localDebug(
         `Version branch pushed: ${branchName}, base version: ${baseVersion}`
       );
@@ -42146,7 +42143,7 @@ async function calculateVersion(context) {
     if (branchName === defaultBranch) {
       localDebug(`Default branch pushed: ${defaultBranch}`);
       const previousRelease = await getLatestReleaseVersion(context.repo);
-      const increment = await getIncrementType(headCommitMessage);
+      const increment = await getIncrementType(context.repo, headCommitMessage);
       const nextVersion = previousRelease.inc(increment);
       return alphaVersion(nextVersion, headCommitTimestamp);
     }
@@ -42168,7 +42165,7 @@ async function calculateVersion(context) {
     let nextVersion;
     if (asVersion !== undefined) {
       localDebug(`Version branch PR: ${baseRef}`);
-      nextVersion = new semver__WEBPACK_IMPORTED_MODULE_2__.SemVer(`${asVersion}.0.0`);
+      nextVersion = new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer(`${asVersion}.0.0`);
     } else {
       const previousRelease = await getLatestReleaseVersion(context.repo);
       const increment = getIncrementTypeFromLabels(prLabels);
@@ -42222,7 +42219,7 @@ function calculateTagVersion(ref) {
   const tag = ref.replace("refs/tags/", "");
   localDebug(`tag: ${tag}`);
   // Ensure it's a valid semver version
-  const parsed = new semver__WEBPACK_IMPORTED_MODULE_2__.SemVer(tag);
+  const parsed = new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer(tag);
   return parsed.version;
 }
 
@@ -42243,15 +42240,16 @@ function tryParseVersionBranch(branchName) {
 
 /**
  * Checks the PR to see if the major version should be incremented based on labels.
+ * @param {{ owner: string, repo: string }} repo
  * @param {string} commitMessage
  * @returns {Promise<'minor' | 'major'>}
  */
-async function getIncrementType(commitMessage) {
+async function getIncrementType(repo, commitMessage) {
   const prNumber = tryParsePrNumber(commitMessage);
   if (prNumber === undefined) {
     return "minor";
   }
-  const labels = await findAssociatedPrLabels(_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo, prNumber);
+  const labels = await findAssociatedPrLabels(repo, prNumber);
   return getIncrementTypeFromLabels(labels);
 }
 
@@ -42301,7 +42299,7 @@ function tryParsePrNumber(commitMessage) {
  * @returns {Promise<{ name: string }[] | undefined>}
  */
 async function findAssociatedPrLabels(repo, prNumber) {
-  const octokit = new octokit__WEBPACK_IMPORTED_MODULE_3__.Octokit({ auth: process.env.GITHUB_TOKEN });
+  const octokit = new octokit__WEBPACK_IMPORTED_MODULE_2__.Octokit({ auth: process.env.GITHUB_TOKEN });
   const pr = await octokit.rest.pulls.get({
     ...repo,
     pull_number: prNumber,
@@ -42315,7 +42313,7 @@ async function findAssociatedPrLabels(repo, prNumber) {
  * @returns {Promise<SemVer>}
  */
 async function getLatestReleaseVersion(repo) {
-  const octokit = new octokit__WEBPACK_IMPORTED_MODULE_3__.Octokit({ auth: process.env.GITHUB_TOKEN });
+  const octokit = new octokit__WEBPACK_IMPORTED_MODULE_2__.Octokit({ auth: process.env.GITHUB_TOKEN });
   try {
     const response = await octokit.rest.repos.getLatestRelease({
       owner: repo.owner,
@@ -42324,29 +42322,30 @@ async function getLatestReleaseVersion(repo) {
     const latestTag = response?.data?.tag_name;
     if (latestTag === undefined) {
       localDebug("No latest release found, using 0.0.0 as the base version.");
-      return new semver__WEBPACK_IMPORTED_MODULE_2__.SemVer("0.0.0");
+      return new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer("0.0.0");
     }
     localDebug(`Latest release tag: ${latestTag}`);
-    const parsed = new semver__WEBPACK_IMPORTED_MODULE_2__.SemVer(latestTag); // Ensure it's a valid semver version
+    const parsed = new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer(latestTag); // Ensure it's a valid semver version
     if (parsed === null) {
       (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.warning)(`Latest release tag is an invalid semver version: ${latestTag}`);
-      return new semver__WEBPACK_IMPORTED_MODULE_2__.SemVer("0.0.0");
+      return new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer("0.0.0");
     }
     return parsed;
   } catch (error) {
     // Prefer always returning some kind of version so we don't break builds due to network issues or unexpected release formats.
     (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.warning)(`Failed to get latest release: ${error.toString()}`);
-    return new semver__WEBPACK_IMPORTED_MODULE_2__.SemVer("0.0.0");
+    return new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer("0.0.0");
   }
 }
 
 /**
  * Returns the ISO timestamp of the commit being built
- * @param {typeof context} context
+ * @param {{ owner: string, repo: string }} repo
+ * @param {string} sha
  * @returns {Promise<string>}
  */
 async function getCommitTimestamp(repo, sha) {
-  const octokit = new octokit__WEBPACK_IMPORTED_MODULE_3__.Octokit({ auth: process.env.GITHUB_TOKEN });
+  const octokit = new octokit__WEBPACK_IMPORTED_MODULE_2__.Octokit({ auth: process.env.GITHUB_TOKEN });
   const currentCommit = await octokit.rest.repos.getCommit({
     ...repo,
     ref: sha,

--- a/version.js
+++ b/version.js
@@ -79,8 +79,12 @@ export async function calculateVersion(context) {
       nextVersion = new SemVer(`${asVersion}.0.0`);
     } else {
       const previousRelease = await getLatestReleaseVersion(context.repo);
-      const increment = getIncrementTypeFromLabels(prLabels);
-      nextVersion = previousRelease.inc(increment);
+      if (isMajorUpgradeBranch(baseRef)) {
+        nextVersion = previousRelease.inc("major");
+      } else {
+        const increment = getIncrementTypeFromLabels(prLabels);
+        nextVersion = previousRelease.inc(increment);
+      }
     }
     const timestamp = await getCommitTimestamp(context.repo, sha);
     const shortHash = context.sha.slice(0, 7);
@@ -179,6 +183,10 @@ async function getDefaultBranchNextVersion(repo, commitMessage) {
       return new SemVer(`${prBranchVersion}.0.0`);
     }
   }
+  // Next, check if the branch name was generated from a major version upgrade
+  if (prRef !== undefined && isMajorUpgradeBranch(prRef)) {
+    return previousRelease.inc("major");
+  }
   // Otherwise, determine the increment type from the PR labels
   const increment = getIncrementTypeFromLabels(pr.data?.labels);
   return previousRelease.inc(increment);
@@ -204,6 +212,15 @@ function getIncrementTypeFromLabels(labels) {
   }
   // Default to minor as this is the most common increment type for providers.
   return "minor";
+}
+
+/**
+ * Tests if the branch name matches the pattern /upgrade-*-major/
+ * @param {string} branchName
+ * @returns {boolean}
+ */
+function isMajorUpgradeBranch(branchName) {
+  return branchName.startsWith("upgrade-") && branchName.endsWith("-major");
 }
 
 /**

--- a/version.test.js
+++ b/version.test.js
@@ -76,6 +76,34 @@ describe("main/master branch pushed", () => {
       })
     ).toBe("0.1.0-alpha.1577836800");
   });
+
+  test("After merging PR with needs-release/major label", async () => {
+    mockGitHubEndpoints({
+      "repos/owner/repo/releases/latest": { tag_name: "v1.0.0" },
+      "repos/owner/repo/pulls/4": {
+        labels: [{ name: "needs-release/major" }],
+      },
+    });
+
+    expect(
+      await calculateVersion({
+        eventName: "push",
+        sha: "699a10d86efd595503aa8c3ecfff753a7ed3cbd4",
+        ref: "refs/heads/master",
+        repo: {
+          owner: "owner",
+          repo: "repo",
+        },
+        payload: {
+          repository: { default_branch: "master" },
+          head_commit: {
+            message: "Commit message (#4)",
+            timestamp: "2020-01-01T00:00:00Z",
+          },
+        },
+      })
+    ).toBe("2.0.0-alpha.1577836800");
+  });
 });
 
 describe("workflow_dispatch", () => {

--- a/version.test.js
+++ b/version.test.js
@@ -132,6 +132,34 @@ describe("main/master branch pushed", () => {
       })
     ).toBe("2.0.0-alpha.1577836800");
   });
+
+  test("After merging major upgrade PR", async () => {
+    mockGitHubEndpoints({
+      "repos/owner/repo/releases/latest": { tag_name: "v1.0.0" },
+      "repos/owner/repo/pulls/4": {
+        head: { ref: "upgrade-xyz-to-v2.0.0-major" },
+      },
+    });
+
+    expect(
+      await calculateVersion({
+        eventName: "push",
+        sha: "699a10d86efd595503aa8c3ecfff753a7ed3cbd4",
+        ref: "refs/heads/v2",
+        repo: {
+          owner: "owner",
+          repo: "repo",
+        },
+        payload: {
+          repository: { default_branch: "master" },
+          head_commit: {
+            message: "Commit message (#4)",
+            timestamp: "2020-01-01T00:00:00Z",
+          },
+        },
+      })
+    ).toBe("2.0.0-alpha.1577836800");
+  });
 });
 
 describe("workflow_dispatch", () => {
@@ -268,6 +296,34 @@ describe("pull_request", () => {
         payload: {
           repository: { default_branch: "main" },
           pull_request: { base: { ref: "v2" } },
+        },
+      })
+    ).toBe("2.0.0-alpha.1577836800+699a10d");
+  });
+
+  test("from major version upgrade", async () => {
+    mockGitHubEndpoints({
+      "repos/owner/repo/releases/latest": { tag_name: "v1.2.1" },
+      "repos/owner/repo/commits/699a10d86efd595503aa8c3ecfff753a7ed3cbd4": {
+        commit: {
+          message: "Commit message",
+          committer: { date: "2020-01-01T00:00:00Z" },
+        },
+      },
+    });
+
+    expect(
+      await calculateVersion({
+        eventName: "pull_request",
+        sha: "699a10d86efd595503aa8c3ecfff753a7ed3cbd4",
+        ref: "refs/pull/4/merge",
+        repo: {
+          owner: "owner",
+          repo: "repo",
+        },
+        payload: {
+          repository: { default_branch: "main" },
+          pull_request: { base: { ref: "upgrade-foo-v2.0.1-major" } },
         },
       })
     ).toBe("2.0.0-alpha.1577836800+699a10d");

--- a/version.test.js
+++ b/version.test.js
@@ -245,6 +245,34 @@ describe("pull_request", () => {
     ).toBe("0.1.0-alpha.1577836800+699a10d");
   });
 
+  test("using version branch", async () => {
+    mockGitHubEndpoints({
+      "repos/owner/repo/releases/latest": { tag_name: "v1.2.1" },
+      "repos/owner/repo/commits/699a10d86efd595503aa8c3ecfff753a7ed3cbd4": {
+        commit: {
+          message: "Commit message",
+          committer: { date: "2020-01-01T00:00:00Z" },
+        },
+      },
+    });
+
+    expect(
+      await calculateVersion({
+        eventName: "pull_request",
+        sha: "699a10d86efd595503aa8c3ecfff753a7ed3cbd4",
+        ref: "refs/pull/4/merge",
+        repo: {
+          owner: "owner",
+          repo: "repo",
+        },
+        payload: {
+          repository: { default_branch: "main" },
+          pull_request: { base: { ref: "v2" } },
+        },
+      })
+    ).toBe("2.0.0-alpha.1577836800+699a10d");
+  });
+
   test("to version branch", async () => {
     mockGitHubEndpoints({
       "repos/owner/repo/commits/699a10d86efd595503aa8c3ecfff753a7ed3cbd4": {

--- a/version.test.js
+++ b/version.test.js
@@ -104,6 +104,34 @@ describe("main/master branch pushed", () => {
       })
     ).toBe("2.0.0-alpha.1577836800");
   });
+
+  test("After merging version branch PR", async () => {
+    mockGitHubEndpoints({
+      "repos/owner/repo/releases/latest": { tag_name: "v1.0.0" },
+      "repos/owner/repo/pulls/4": {
+        head: { ref: "v2" },
+      },
+    });
+
+    expect(
+      await calculateVersion({
+        eventName: "push",
+        sha: "699a10d86efd595503aa8c3ecfff753a7ed3cbd4",
+        ref: "refs/heads/v2",
+        repo: {
+          owner: "owner",
+          repo: "repo",
+        },
+        payload: {
+          repository: { default_branch: "master" },
+          head_commit: {
+            message: "Commit message (#4)",
+            timestamp: "2020-01-01T00:00:00Z",
+          },
+        },
+      })
+    ).toBe("2.0.0-alpha.1577836800");
+  });
 });
 
 describe("workflow_dispatch", () => {


### PR DESCRIPTION
We've decided to prefer using version branches (e.g. `v2`) for using during a major version upgrade instead of PR labels as labels can be forgotten or modified mid-build.

This PR therefore handles the next build on the default branch after the version branch has been merged into it. This looks up the branch name associated with PR last merged into the HEAD commit and checks if it was a `v` followed by a number. If it was a version branch that was merged, the version will be based on the number used in the branch name (e.g. `2.0.0-alpha.1577836800` for the `v2` branch).

This PR also adds testing for the existing support of PRs having a `needs-release/major` label assigned in the first commit - along with a minor refactor to avoid global variables to make the unit testing possible.