### PR TITLE
Check the PR head ref, not base ref for current branch name

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -42161,20 +42161,20 @@ async function calculateVersion(context) {
 
   if (eventName === "pull_request") {
     // pull_request events only
-    const baseRef = context.payload?.pull_request?.base?.ref;
+    const headRef = context.payload?.pull_request?.head?.ref;
     const prLabels = context.payload?.pull_request?.labels;
     localDebug(`PR pushed: ${context.eventName} ${context.ref}`);
-    localDebug(`pull_request.base.ref: ${baseRef}`);
+    localDebug(`pull_request.head.ref: ${headRef}`);
     localDebug(`pull_request.labels: ${JSON.stringify(prLabels)}`);
 
-    const asVersion = tryParseVersionBranch(baseRef);
+    const asVersion = tryParseVersionBranch(headRef);
     let nextVersion;
     if (asVersion !== undefined) {
-      localDebug(`Version branch PR: ${baseRef}`);
+      localDebug(`Version branch PR: ${headRef}`);
       nextVersion = new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer(`${asVersion}.0.0`);
     } else {
       const previousRelease = await getLatestReleaseVersion(context.repo);
-      if (isMajorUpgradeBranch(baseRef)) {
+      if (isMajorUpgradeBranch(headRef)) {
         nextVersion = previousRelease.inc("major");
       } else {
         const increment = getIncrementTypeFromLabels(prLabels);
@@ -42238,6 +42238,9 @@ function calculateTagVersion(ref) {
  * @returns {number | undefined}
  */
 function tryParseVersionBranch(branchName) {
+  if (!branchName) {
+    return undefined;
+  }
   const match = branchName.match(/^v(\d+)$/);
   if (match) {
     const version = parseInt(match[1], 10);
@@ -42315,6 +42318,9 @@ function getIncrementTypeFromLabels(labels) {
  * @returns {boolean}
  */
 function isMajorUpgradeBranch(branchName) {
+  if (!branchName) {
+    return false;
+  }
   return branchName.startsWith("upgrade-") && branchName.endsWith("-major");
 }
 

--- a/version.js
+++ b/version.js
@@ -71,20 +71,20 @@ export async function calculateVersion(context) {
 
   if (eventName === "pull_request") {
     // pull_request events only
-    const baseRef = context.payload?.pull_request?.base?.ref;
+    const headRef = context.payload?.pull_request?.head?.ref;
     const prLabels = context.payload?.pull_request?.labels;
     localDebug(`PR pushed: ${context.eventName} ${context.ref}`);
-    localDebug(`pull_request.base.ref: ${baseRef}`);
+    localDebug(`pull_request.head.ref: ${headRef}`);
     localDebug(`pull_request.labels: ${JSON.stringify(prLabels)}`);
 
-    const asVersion = tryParseVersionBranch(baseRef);
+    const asVersion = tryParseVersionBranch(headRef);
     let nextVersion;
     if (asVersion !== undefined) {
-      localDebug(`Version branch PR: ${baseRef}`);
+      localDebug(`Version branch PR: ${headRef}`);
       nextVersion = new SemVer(`${asVersion}.0.0`);
     } else {
       const previousRelease = await getLatestReleaseVersion(context.repo);
-      if (isMajorUpgradeBranch(baseRef)) {
+      if (isMajorUpgradeBranch(headRef)) {
         nextVersion = previousRelease.inc("major");
       } else {
         const increment = getIncrementTypeFromLabels(prLabels);
@@ -148,6 +148,9 @@ function calculateTagVersion(ref) {
  * @returns {number | undefined}
  */
 function tryParseVersionBranch(branchName) {
+  if (!branchName) {
+    return undefined;
+  }
   const match = branchName.match(/^v(\d+)$/);
   if (match) {
     const version = parseInt(match[1], 10);
@@ -225,6 +228,9 @@ function getIncrementTypeFromLabels(labels) {
  * @returns {boolean}
  */
 function isMajorUpgradeBranch(branchName) {
+  if (!branchName) {
+    return false;
+  }
   return branchName.startsWith("upgrade-") && branchName.endsWith("-major");
 }
 

--- a/version.test.js
+++ b/version.test.js
@@ -324,7 +324,10 @@ describe("pull_request", () => {
         },
         payload: {
           repository: { default_branch: "main" },
-          pull_request: { base: { ref: "v2" } },
+          pull_request: {
+            base: { ref: "main" },
+            head: { ref: "v2" },
+          },
         },
       })
     ).toBe("2.0.0-alpha.1577836800+699a10d");
@@ -352,7 +355,10 @@ describe("pull_request", () => {
         },
         payload: {
           repository: { default_branch: "main" },
-          pull_request: { base: { ref: "upgrade-foo-v2.0.1-major" } },
+          pull_request: {
+            base: { ref: "main" },
+            head: { ref: "upgrade-foo-v2.0.1-major" },
+          },
         },
       })
     ).toBe("2.0.0-alpha.1577836800+699a10d");
@@ -379,7 +385,10 @@ describe("pull_request", () => {
         },
         payload: {
           repository: { default_branch: "main" },
-          pull_request: { base: { ref: "v21" } },
+          pull_request: {
+            base: { ref: "main" },
+            head: { ref: "v21" },
+          },
         },
       })
     ).toBe("21.0.0-alpha.1577836800+699a10d");


### PR DESCRIPTION
The base of a PR is where it's merging into (e.g. "main"), but we want to know the name of the branch that is *being* merged. This is the 'head'.

We can't use the `context.ref` because this is the merge target e.g. `refs/pull/524/merge`

See example from debug logs:
- [`head.ref`](https://github.com/pulumi/pulumi-oci/actions/runs/9719486666/job/26934553104#step:3:286): `upgrade-terraform-provider-oci-to-v6.0.0-major`
- [`base.ref`](https://github.com/pulumi/pulumi-oci/actions/runs/9719486666/job/26934553104#step:3:133): `main`
- [`ref`](https://github.com/pulumi/pulumi-oci/actions/runs/9719486666/job/26934553104#step:3:607): `refs/pull/524/merge`

Made branch functions a little more robust against missing values.

Fixes #9 