### PR TITLE
Allow setting major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The calculated version is always valid [semver 2.0.0](https://semver.org/) – w
 ```yaml
 - uses: pulumi/provider-version-action@v1
   with:
+    # Recommended major version to based generated version numbers on.
+    # If not specified, the major version will attempt to be inferred from the context.
+    major-version: 1
     # Optional name of the environment variable to set with the calculated version, for example: PROVIDER_VERSION
     # Defaults to empty which results in no environment variable being set.
     set-env: ''
@@ -72,13 +75,13 @@ jobs:
 
 This action supports 3 build scenarios:
 
-1. Pushing a version tag beginning with "v" (e.g. `v1.2.3`). The version from the tag will be used e.g. `1.2.3`
+1. Pushing a version tag beginning with "v" (e.g. `v1.2.3`). The exact version from the tag will be used e.g. `1.2.3`. This is not affected by the `major-version` input.
 2. Pushing to a main branch. An alpha version will be generated e.g. `1.2.3-alpha.1577836800`
 3. Building a pull request. An alpha version will be generated, with a shorthash suffix e.g. `1.2.3-alpha.1577836800+699a10d`
 
-### Major Versions
+### Implicit Major Versions
 
-When we're wanting to build for a different major version from the last release, we can do this using three methods:
+If we've not specified an explicit major version input, when we're wanting to build for a different major version from the last release, we can do this using three methods:
 
 1. Use a version branch containing just the major version number e.g. (`v1` or `v7`). Pushing to this branch, or opening a pull request with this branch as the "base" will use this major version.
 2. Name the branch with prefix `upgrade-` and suffix `-major` (e.g. `upgrade-aws-to-v2.0.0-major`). This will cause the version number to be incremented by a major increment instead of a minor increment.

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,17 @@
-name: 'Provider Version'
-description: 'Calculate the version to be used during a Pulumi provider build.'
+name: "Provider Version"
+description: "Calculate the version to be used during a Pulumi provider build."
 inputs:
   set-env:
     required: false
-    description: 'Optional name of the environment variable to set with the calculated version.'
+    description: "Optional name of the environment variable to set with the calculated version."
+  major-version:
+    required: false
+    description: |
+      Forces a specific major version, if specified, otherwise will be inferred from contextual information.
+      Ignored for explicit tag pushes.
 outputs:
   version:
-    description: 'The calculated version'
+    description: "The calculated version"
 runs:
-  using: 'node20'
-  main: 'dist/index.js'
+  using: "node20"
+  main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -42114,6 +42114,8 @@ try {
 // Only write debug messages when the RUNNER_DEBUG environment variable is set.
 // This reduces noise in tests.
 const localDebug = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.isDebug)() ? _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug : () => {};
+// Skip writing info messages when running in Jest to reduce noise.
+const localInfo = process.env.JEST_WORKER_ID !== undefined ? () => {} : _actions_core__WEBPACK_IMPORTED_MODULE_0__.info;
 
 /**
  * Calculate the version to use for the current build.
@@ -42422,7 +42424,11 @@ function ensureMajorVersion(version, majorVersion) {
     return version;
   }
   // Reset to requested major version.
-  return new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer(`${majorVersion}.0.0`);
+  const fixedVersion = new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer(`${majorVersion}.0.0`);
+  localInfo(
+    `Expected major version ${majorVersion}, but would have inferred ${version}. Resetting to ${fixedVersion}.`
+  );
+  return fixedVersion;
 }
 
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -17,7 +17,8 @@ __nccwpck_require__.r(__webpack_exports__);
 
 
 try {
-  const version = await (0,_version__WEBPACK_IMPORTED_MODULE_2__/* .calculateVersion */ .x)(_actions_github__WEBPACK_IMPORTED_MODULE_1__.context);
+  const majorVersion = parseMajorVersion((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)("major-version"));
+  const version = await (0,_version__WEBPACK_IMPORTED_MODULE_2__/* .calculateVersion */ .x)(_actions_github__WEBPACK_IMPORTED_MODULE_1__.context, { majorVersion });
   (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Calculated version: ${version}`);
   (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput)("version", version);
   const envVar = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)("set-env");
@@ -26,6 +27,24 @@ try {
   }
 } catch (error) {
   (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed)(error);
+}
+
+/**
+ *
+ * @param {string} majorVersion
+ * @returns {number | undefined}
+ */
+function parseMajorVersion(majorVersion) {
+  if (majorVersion === "") {
+    return undefined;
+  }
+  const parsed = parseInt(majorVersion, 10);
+  if (isNaN(parsed)) {
+    throw new Error(
+      `Invalid major version: ${majorVersion}. Must be an integer.`
+    );
+  }
+  return parsed;
 }
 
 __webpack_async_result__();
@@ -42098,15 +42117,17 @@ const localDebug = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.isDebug)() ? _a
 
 /**
  * Calculate the version to use for the current build.
- * @param {any} fetch
  * @param {import("@actions/github/lib/context").Context} context
+ * @param {{ majorVersion?: number }} args
  */
-async function calculateVersion(context) {
+async function calculateVersion(context, args) {
+  const majorVersion = args?.majorVersion;
   const eventName = context.eventName;
   const ref = context.ref;
   const sha = context.sha;
   const defaultBranch = context.payload?.repository?.default_branch;
 
+  localDebug(`major-version: ${majorVersion ?? ""}`);
   localDebug(`event_name: ${eventName}`);
   localDebug(`ref: ${ref}`);
   localDebug(`sha: ${sha}`);
@@ -42144,7 +42165,10 @@ async function calculateVersion(context) {
       localDebug(
         `Version branch pushed: ${branchName}, base version: ${baseVersion}`
       );
-      return alphaVersion(baseVersion, headCommitTimestamp);
+      return alphaVersion(
+        ensureMajorVersion(baseVersion, majorVersion),
+        headCommitTimestamp
+      );
     }
     if (branchName === defaultBranch) {
       localDebug(`Default branch pushed: ${defaultBranch}`);
@@ -42152,12 +42176,19 @@ async function calculateVersion(context) {
         context.repo,
         headCommitMessage
       );
-      return alphaVersion(nextVersion, headCommitTimestamp);
+      return alphaVersion(
+        ensureMajorVersion(nextVersion, majorVersion),
+        headCommitTimestamp
+      );
     }
     localDebug(`Branch pushed: ${branchName}`);
     const previousRelease = await getLatestReleaseVersion(context.repo);
     const nextVersion = previousRelease.inc("minor");
-    return localAlphaVersion(nextVersion, headCommitTimestamp, sha);
+    return localAlphaVersion(
+      ensureMajorVersion(nextVersion, majorVersion),
+      headCommitTimestamp,
+      sha
+    );
   }
 
   if (eventName === "pull_request") {
@@ -42182,6 +42213,7 @@ async function calculateVersion(context) {
         nextVersion = previousRelease.inc(increment);
       }
     }
+    nextVersion = ensureMajorVersion(nextVersion, majorVersion);
     const { timestamp } = await getCommit(context.repo, sha);
     const shortHash = context.sha.slice(0, 7);
     return localAlphaVersion(nextVersion, timestamp, shortHash);
@@ -42189,7 +42221,9 @@ async function calculateVersion(context) {
 
   if (eventName === "schedule" || eventName === "repository_dispatch") {
     const previousRelease = await getLatestReleaseVersion(context.repo);
-    const nextVersion = previousRelease.inc("minor");
+    let nextVersion = previousRelease.inc("minor");
+    // If a major version is provided, ensure we're using that major version.
+    nextVersion = ensureMajorVersion(nextVersion, majorVersion);
     const { timestamp } = await getCommit(context.repo, sha);
     const shortHash = context.sha.slice(0, 7);
     return localAlphaVersion(nextVersion, timestamp, shortHash);
@@ -42345,7 +42379,7 @@ function tryParsePrNumber(commitMessage) {
 
 /**
  * Get the latest release version from GitHub.
- * @param {{ owner: string, repo: string}} repo
+ * @param {{ owner: string, repo: string}} repo Repository to load releases from.
  * @returns {Promise<SemVer>}
  */
 async function getLatestReleaseVersion(repo) {
@@ -42372,6 +42406,23 @@ async function getLatestReleaseVersion(repo) {
     (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.warning)(`Failed to get latest release: ${error.toString()}`);
     return new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer("0.0.0");
   }
+}
+
+/**
+ *
+ * @param {SemVer} version
+ * @param {number | undefined} majorVersion
+ * @returns {SemVer}
+ */
+function ensureMajorVersion(version, majorVersion) {
+  if (majorVersion === undefined) {
+    return version;
+  }
+  if (version.major == majorVersion) {
+    return version;
+  }
+  // Reset to requested major version.
+  return new semver__WEBPACK_IMPORTED_MODULE_1__.SemVer(`${majorVersion}.0.0`);
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ import * as github from "@actions/github";
 import { calculateVersion } from "./version";
 
 try {
-  const version = await calculateVersion(github.context);
+  const majorVersion = parseMajorVersion(getInput("major-version"));
+  const version = await calculateVersion(github.context, { majorVersion });
   info(`Calculated version: ${version}`);
   setOutput("version", version);
   const envVar = getInput("set-env");
@@ -18,4 +19,22 @@ try {
   }
 } catch (error) {
   setFailed(error);
+}
+
+/**
+ *
+ * @param {string} majorVersion
+ * @returns {number | undefined}
+ */
+function parseMajorVersion(majorVersion) {
+  if (majorVersion === "") {
+    return undefined;
+  }
+  const parsed = parseInt(majorVersion, 10);
+  if (isNaN(parsed)) {
+    throw new Error(
+      `Invalid major version: ${majorVersion}. Must be an integer.`
+    );
+  }
+  return parsed;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3101,12 +3101,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -3365,9 +3365,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3592,9 +3592,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4709,12 +4709,12 @@
       "dev": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/version.js
+++ b/version.js
@@ -94,6 +94,7 @@ export async function calculateVersion(context, args) {
         nextVersion = previousRelease.inc(increment);
       }
     }
+    nextVersion = ensureMajorVersion(nextVersion, majorVersion);
     const { timestamp } = await getCommit(context.repo, sha);
     const shortHash = context.sha.slice(0, 7);
     return localAlphaVersion(nextVersion, timestamp, shortHash);

--- a/version.js
+++ b/version.js
@@ -1,10 +1,12 @@
-import { warning, debug, isDebug, group } from "@actions/core";
+import { warning, debug, isDebug, info, group } from "@actions/core";
 import { SemVer } from "semver";
 import { Octokit } from "octokit";
 
 // Only write debug messages when the RUNNER_DEBUG environment variable is set.
 // This reduces noise in tests.
 const localDebug = isDebug() ? debug : () => {};
+// Skip writing info messages when running in Jest to reduce noise.
+const localInfo = process.env.JEST_WORKER_ID !== undefined ? () => {} : info;
 
 /**
  * Calculate the version to use for the current build.
@@ -313,7 +315,11 @@ function ensureMajorVersion(version, majorVersion) {
     return version;
   }
   // Reset to requested major version.
-  return new SemVer(`${majorVersion}.0.0`);
+  const fixedVersion = new SemVer(`${majorVersion}.0.0`);
+  localInfo(
+    `Expected major version ${majorVersion}, but would have inferred ${version}. Resetting to ${fixedVersion}.`
+  );
+  return fixedVersion;
 }
 
 /**

--- a/version.js
+++ b/version.js
@@ -8,15 +8,17 @@ const localDebug = isDebug() ? debug : () => {};
 
 /**
  * Calculate the version to use for the current build.
- * @param {any} fetch
  * @param {import("@actions/github/lib/context").Context} context
+ * @param {{ majorVersion?: number }} args
  */
-export async function calculateVersion(context) {
+export async function calculateVersion(context, args) {
+  const majorVersion = args?.majorVersion;
   const eventName = context.eventName;
   const ref = context.ref;
   const sha = context.sha;
   const defaultBranch = context.payload?.repository?.default_branch;
 
+  localDebug(`major-version: ${majorVersion ?? ""}`);
   localDebug(`event_name: ${eventName}`);
   localDebug(`ref: ${ref}`);
   localDebug(`sha: ${sha}`);

--- a/version.js
+++ b/version.js
@@ -56,7 +56,10 @@ export async function calculateVersion(context, args) {
       localDebug(
         `Version branch pushed: ${branchName}, base version: ${baseVersion}`
       );
-      return alphaVersion(baseVersion, headCommitTimestamp);
+      return alphaVersion(
+        ensureMajorVersion(baseVersion, majorVersion),
+        headCommitTimestamp
+      );
     }
     if (branchName === defaultBranch) {
       localDebug(`Default branch pushed: ${defaultBranch}`);
@@ -64,12 +67,19 @@ export async function calculateVersion(context, args) {
         context.repo,
         headCommitMessage
       );
-      return alphaVersion(nextVersion, headCommitTimestamp);
+      return alphaVersion(
+        ensureMajorVersion(nextVersion, majorVersion),
+        headCommitTimestamp
+      );
     }
     localDebug(`Branch pushed: ${branchName}`);
     const previousRelease = await getLatestReleaseVersion(context.repo);
     const nextVersion = previousRelease.inc("minor");
-    return localAlphaVersion(nextVersion, headCommitTimestamp, sha);
+    return localAlphaVersion(
+      ensureMajorVersion(nextVersion, majorVersion),
+      headCommitTimestamp,
+      sha
+    );
   }
 
   if (eventName === "pull_request") {

--- a/version.test.js
+++ b/version.test.js
@@ -541,6 +541,33 @@ describe("schedule", () => {
       })
     ).toBe("1.3.0-alpha.1577836800+699a10d");
   });
+
+  test("with explicit major version", async () => {
+    mockGitHubEndpoints({
+      "repos/owner/repo/releases/latest": { tag_name: "v1.2.1" },
+      "repos/owner/repo/commits/699a10d86efd595503aa8c3ecfff753a7ed3cbd4": {
+        commit: {
+          message: "Commit message",
+          committer: { date: "2020-01-01T00:00:00Z" },
+        },
+      },
+    });
+
+    expect(
+      await calculateVersion(
+        {
+          eventName: "schedule",
+          sha: "699a10d86efd595503aa8c3ecfff753a7ed3cbd4",
+          ref: "refs/heads/master",
+          repo: {
+            owner: "owner",
+            repo: "repo",
+          },
+        },
+        { majorVersion: 2 }
+      )
+    ).toBe("2.0.0-alpha.1577836800+699a10d");
+  });
 });
 
 function mockGitHubEndpoints(requests = {}) {

--- a/version.test.js
+++ b/version.test.js
@@ -334,6 +334,68 @@ describe("pull_request", () => {
     ).toBe("1.3.0-alpha.1577836800+699a10d");
   });
 
+  test("with expected major version", async () => {
+    mockGitHubEndpoints({
+      "repos/owner/repo/releases/latest": { tag_name: "v1.2.1" },
+      "repos/owner/repo/commits/699a10d86efd595503aa8c3ecfff753a7ed3cbd4": {
+        commit: {
+          message: "Commit message",
+          committer: { date: "2020-01-01T00:00:00Z" },
+        },
+      },
+    });
+
+    expect(
+      await calculateVersion(
+        {
+          eventName: "pull_request",
+          sha: "699a10d86efd595503aa8c3ecfff753a7ed3cbd4",
+          ref: "refs/pull/4/merge",
+          repo: {
+            owner: "owner",
+            repo: "repo",
+          },
+          payload: {
+            repository: { default_branch: "main" },
+            pull_request: { base: { ref: "main" } },
+          },
+        },
+        { majorVersion: 1 }
+      )
+    ).toBe("1.3.0-alpha.1577836800+699a10d");
+  });
+
+  test("with overriding major version", async () => {
+    mockGitHubEndpoints({
+      "repos/owner/repo/releases/latest": { tag_name: "v1.2.1" },
+      "repos/owner/repo/commits/699a10d86efd595503aa8c3ecfff753a7ed3cbd4": {
+        commit: {
+          message: "Commit message",
+          committer: { date: "2020-01-01T00:00:00Z" },
+        },
+      },
+    });
+
+    expect(
+      await calculateVersion(
+        {
+          eventName: "pull_request",
+          sha: "699a10d86efd595503aa8c3ecfff753a7ed3cbd4",
+          ref: "refs/pull/4/merge",
+          repo: {
+            owner: "owner",
+            repo: "repo",
+          },
+          payload: {
+            repository: { default_branch: "main" },
+            pull_request: { base: { ref: "main" } },
+          },
+        },
+        { majorVersion: 2 }
+      )
+    ).toBe("2.0.0-alpha.1577836800+699a10d");
+  });
+
   test("without previous release", async () => {
     mockGitHubEndpoints({
       "repos/owner/repo/releases/latest": {},

--- a/version.test.js
+++ b/version.test.js
@@ -77,6 +77,35 @@ describe("main/master branch pushed", () => {
     ).toBe("0.1.0-alpha.1577836800");
   });
 
+  test("with explicit major version", async () => {
+    mockGitHubEndpoints({
+      // Make release not found
+      "repos/owner/repo/releases/latest": {},
+    });
+
+    expect(
+      await calculateVersion(
+        {
+          eventName: "push",
+          sha: "699a10d86efd595503aa8c3ecfff753a7ed3cbd4",
+          ref: "refs/heads/master",
+          repo: {
+            owner: "owner",
+            repo: "repo",
+          },
+          payload: {
+            repository: { default_branch: "master" },
+            head_commit: {
+              message: "Commit message",
+              timestamp: "2020-01-01T00:00:00Z",
+            },
+          },
+        },
+        { majorVersion: 2 }
+      )
+    ).toBe("2.0.0-alpha.1577836800");
+  });
+
   test("After merging PR with needs-release/major label", async () => {
     mockGitHubEndpoints({
       "repos/owner/repo/releases/latest": { tag_name: "v1.0.0" },
@@ -302,6 +331,32 @@ describe("Version branch pushed", () => {
         },
       })
     ).toBe("2.0.0-alpha.1577836800");
+  });
+
+  test("with explicit major version", async () => {
+    mockGitHubEndpoints({});
+
+    expect(
+      await calculateVersion(
+        {
+          eventName: "push",
+          sha: "699a10d86efd595503aa8c3ecfff753a7ed3cbd4",
+          ref: "refs/heads/v2",
+          repo: {
+            owner: "owner",
+            repo: "repo",
+          },
+          payload: {
+            repository: { default_branch: "master" },
+            head_commit: {
+              message: "Commit message",
+              timestamp: "2020-01-01T00:00:00Z",
+            },
+          },
+        },
+        { majorVersion: 3 }
+      )
+    ).toBe("3.0.0-alpha.1577836800");
   });
 });
 


### PR DESCRIPTION
Fixes #13 

The inference of the major version can currently lead to some unexpected results. Add an option to pass in the expected major version to this action to ensure the major version is the desired value.

The only exception where the major version is ignored is when pushing tags. Tags are expected to be the exact version to publish, so we don't do any kind of inferrence there.