### PR TITLE
Automate floating tag updates and document release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+
+      - name: Update floating major version tag
+        run: |
+          # Extract major version (v1.2.3 -> 1)
+          MAJOR_VERSION=$(echo "${{ github.ref_name }}" | sed -E 's/v([0-9]+)\..*/\1/')
+          MAJOR_TAG="v${MAJOR_VERSION}"
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Update floating tag
+          git tag -f "$MAJOR_TAG"
+          git push -f origin "$MAJOR_TAG"
+
+          echo "Updated $MAJOR_TAG to point to ${{ github.ref_name }}"

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -2,7 +2,9 @@ name: Self-test
 on:
   workflow_dispatch: {}
   pull_request: {}
-  push: {}
+  push:
+    branches:
+      - '**'
 
 jobs:
   self-test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,80 @@ You must re-generate the `dist/` folder after making any changes.
 
 1. Run `npm test` after any changes to ensure the unit tests pass.
 2. Run `npm run build` to re-generate the `dist/` folder. Any changes should be committed.
+
+## Releases
+
+### Creating a Release
+
+Releases are created by repository maintainers by pushing a semantic version tag. When you push a version tag (e.g., `v1.7.0`), the automated release workflow will:
+
+1. Create a GitHub release with auto-generated release notes
+2. Update the floating major version tag (e.g., `v1` will point to the latest `v1.x.x` release)
+
+This allows users to reference the action as `pulumi/provider-version-action@v1` and automatically receive bug fixes and non-breaking updates.
+
+### Semantic Versioning
+
+This project follows [Semantic Versioning 2.0.0](https://semver.org/):
+
+- **MAJOR version** (`v2.0.0`): Incompatible API changes
+- **MINOR version** (`v1.7.0`): New functionality in a backwards compatible manner
+- **PATCH version** (`v1.6.1`): Backwards compatible bug fixes
+
+### Release Checklist
+
+Before creating a release tag, ensure:
+
+1. All changes are merged to the `main` branch
+2. Tests pass: `npm test`
+3. Build is up-to-date: `npm run build`
+4. The `dist/` folder contains the latest compiled code and is committed
+5. The [self-test workflow](https://github.com/pulumi/provider-version-action/actions/workflows/self-test.yml) is passing on `main`
+
+### Creating a Release Tag
+
+The easiest way to create a release is using the release script:
+
+```bash
+# This will test, build, update package.json, and create the tag
+npm run release 1.7.0
+```
+
+The script will:
+1. Ensure you're on the latest `main` branch
+2. Run tests and build
+3. Update `package.json` version
+4. Commit the version bump
+5. Create and push the version tag
+
+Alternatively, you can create a tag manually:
+
+```bash
+# Ensure you're on latest main
+git checkout main
+git pull origin main
+
+# Update package.json version
+npm version 1.7.0 --no-git-tag-version
+git add package.json
+git commit -m "Bump version to 1.7.0"
+git push origin main
+
+# Create and push the tag
+git tag v1.7.0
+git push origin v1.7.0
+```
+
+The release workflow will automatically handle the rest.
+
+### Manual Tag Update (Emergency Only)
+
+If the automated workflow fails or you need to manually update a floating tag:
+
+```bash
+# Force update the major version tag to a specific release
+git tag -f v1 v1.6.0
+git push -f origin v1
+```
+
+**Note**: Floating tags (e.g., `v1`, `v2`) are moving targets that change with each release. Users who pin to specific versions (e.g., `v1.6.0`) are not affected by floating tag updates.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest",
     "build": "ncc build index.js -o dist",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "release": "./release.sh"
   },
   "keywords": [],
   "author": "",

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if version is provided
+if [ -z "$1" ]; then
+    echo -e "${RED}Error: Version number required${NC}"
+    echo "Usage: npm run release <version>"
+    echo "Example: npm run release 1.7.0"
+    exit 1
+fi
+
+VERSION=$1
+
+# Validate version format (should be X.Y.Z without 'v' prefix)
+if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo -e "${RED}Error: Version must be in format X.Y.Z (e.g., 1.7.0)${NC}"
+    exit 1
+fi
+
+TAG="v${VERSION}"
+
+echo -e "${YELLOW}Creating release ${TAG}${NC}"
+
+# Ensure we're on main and up to date
+echo "Checking out main branch..."
+git checkout main
+git pull origin main
+
+# Run tests
+echo "Running tests..."
+npm test
+
+# Build
+echo "Building..."
+npm run build
+
+# Check for uncommitted changes
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo -e "${RED}Error: You have uncommitted changes. Please commit or stash them first.${NC}"
+    git status --short
+    exit 1
+fi
+
+# Update package.json version
+echo "Updating package.json version to ${VERSION}..."
+npm version ${VERSION} --no-git-tag-version
+git add package.json
+git commit -m "Bump version to ${VERSION}"
+git push origin main
+
+# Create and push tag
+echo "Creating tag ${TAG}..."
+git tag ${TAG}
+git push origin ${TAG}
+
+echo -e "${GREEN}✓ Release ${TAG} created successfully!${NC}"
+echo ""
+echo "Next steps:"
+echo "1. Monitor the release workflow: https://github.com/pulumi/provider-version-action/actions/workflows/release.yml"
+echo "2. Edit release notes if needed: https://github.com/pulumi/provider-version-action/releases"


### PR DESCRIPTION
Fixes #16

This PR adds automation to keep floating major version tags (like `v1`) up to date and streamlines the release process.

## Changes

- **New `.github/workflows/release.yml` workflow** that triggers on version tag pushes
  - Automatically creates GitHub releases with generated notes
  - Automatically updates floating major version tags
- **New `release.sh` script** for streamlined releases
  - Runs tests and builds
  - Updates package.json version
  - Creates and pushes version tags
- **Updated `package.json`** with `npm run release` command
- **Updated `CONTRIBUTING.md`** with comprehensive release documentation

## How it works

1. Run: `npm run release 1.7.0`
2. Script tests, builds, updates package.json, and pushes tag
3. Workflow creates the GitHub release
4. Workflow updates the `v1` floating tag to point to `v1.7.0`

## Immediate fix applied

The current `v1` tag was already updated to point to v1.6.0 (from v1.0.0) to unblock dependent repositories experiencing CI failures.

## Testing

Once merged, the next version tag push will test the workflow. The workflow:
- Validates tag format (vX.Y.Z)
- Creates GitHub release with auto-generated notes
- Updates the major version floating tag automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)